### PR TITLE
Fixes for HM-RPI-MOD-PCB

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Direktverknüpfungen.
 
 #### Voraussetzungen
 
-Hmcon benötigt (falls man den Homematic Manager nutzen will) eine [Nodejs](https://nodejs.org/) Installation.
+Hmcon benötigt (falls man den Homematic Manager nutzen will) eine [Node.js<sup>&reg;</sup>](https://nodejs.org/) Installation.
 
-Für Debian armhf (RaspberryPi, ...) siehe https://github.com/nathanjohnson320/node_arm
+Für Debian armhf (RaspberryPi, ...) siehe   
+https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
 
 
 
@@ -29,9 +30,7 @@ Hmcon wird mit einem interaktiven Shell-Script installiert, dass die benötigten
 Konfigurationsdateien und Startscripte anlegt.
 
 ```Shell
-wget https://github.com/hobbyquaker/hmcon/raw/master/hmcon-setup.sh
-chmod a+x hmcon-setup.sh
-sudo ./hmcon-setup.sh
+curl -sL https://raw.githubusercontent.com/ploebb/hmcon/master/hmcon-setup.sh | sudo -E bash -
 ```
 
 Updates können ebenfalls mit hmcon-setup.sh durchgeführt werden.

--- a/hmcon-setup.sh
+++ b/hmcon-setup.sh
@@ -135,43 +135,43 @@ SetupGPIO="# export GPIO
   fi
 "
                     # disable serial console (code from raspi-config)
-					echo "disabling serial-console"
-					if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
-						SYSTEMD=1
-					elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
-						SYSTEMD=0
-					else
-						echo "[Warning] Unrecognised init system"
-					fi
-					
-					if [ $SYSTEMD -eq 0 ]; then
-						sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
-					fi
-					sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
-					sed -i /boot/cmdline.txt -e "s/console=serial0,[0-9]\+ //"
-					ASK_TO_REBOOT=1
-					
+                    echo "disabling serial-console"
+                    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+                        SYSTEMD=1
+                    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+                        SYSTEMD=0
+                    else
+                        echo "[Warning] Unrecognised init system"
+                    fi
+                    
+                    if [ $SYSTEMD -eq 0 ]; then
+                        sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
+                    fi
+                    sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
+                    sed -i /boot/cmdline.txt -e "s/console=serial0,[0-9]\+ //"
+                    ASK_TO_REBOOT=1
+                    
                     # allow hmcon gpio access when using HM-MOD-RPI-PCB
-					# if group gpio doesn't exist, creat it and create a corresponding udev-rule
-					if ! grep gpio /etc/group >/dev/null 2>&1; then
-						groupadd gpio
-						UDEVFILE=99-rfd-gpio.rules
-						echo "creating new udev-rule for gpio"
+                    # if group gpio doesn't exist, creat it and create a corresponding udev-rule
+                    if ! grep gpio /etc/group >/dev/null 2>&1; then
+                        groupadd gpio
+                        UDEVFILE=99-rfd-gpio.rules
+                        echo "creating new udev-rule for gpio"
 cat > /etc/udev/rules.d/$UDEVFILE <<- EOM
 SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio; chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio; chown -R root:gpio /sys/devices/platform/soc/*.gpio/gpio && chmod -R 770 /sys/devices/platform/soc/*.gpio/gpio'"
 EOM
-						if grep "SUBSYSTEM==\"gpio\"" --exclude=$UDEVFILE /etc/udev/rules.d/* >/dev/null 2>&1; then
-							echo ""
-							echo "[WARNING] Another udev-rule for the gpios is already in place and may conflict with the one added here.\r"
-							echo "[WARNING] The rule in question is: "
-							grep "SUBSYSTEM==\"gpio\"" --exclude=$UDEVFILE /etc/udev/rules.d/*
-							echo "[WARNING] Check rfd.log for errors"
-						fi
-						udevadm control --reload-rules
-					fi
-					
-					echo "adding user hmcon to gpio and dialout group"
-					usermod -a -G gpio,dialout $USER
+                        if grep "SUBSYSTEM==\"gpio\"" --exclude=$UDEVFILE /etc/udev/rules.d/* >/dev/null 2>&1; then
+                            echo ""
+                            echo "[WARNING] Another udev-rule for the gpios is already in place and may conflict with the one added here.\r"
+                            echo "[WARNING] The rule in question is: "
+                            grep "SUBSYSTEM==\"gpio\"" --exclude=$UDEVFILE /etc/udev/rules.d/*
+                            echo "[WARNING] Check rfd.log for errors"
+                        fi
+                        udevadm control --reload-rules
+                    fi
+                    
+                    echo "adding user hmcon to gpio and dialout group"
+                    usermod -a -G gpio,dialout $USER
 cat >> $ETC/rfd.conf <<- EOM
 [Interface $i]
 Type = CCU2
@@ -236,7 +236,7 @@ EOM
                 esac
             done
 
-			echo ""
+            echo ""
             read -p "Add another rf interface (y/N)? " choice
             case "$choice" in
                 y|Y )
@@ -689,7 +689,7 @@ if [ $ASK_TO_REBOOT -eq 1 ]; then
     case "$choice" in
         n|N ) ;;
         * )
-			shutdown -r now
+            shutdown -r now
         ;;
     esac
 fi

--- a/hmcon-setup.sh
+++ b/hmcon-setup.sh
@@ -7,6 +7,7 @@ PREFIX=/opt/hmcon
 VAR=$PREFIX/var
 ETC=$PREFIX/etc
 
+ASK_TO_REBOOT=0
 echo ""
 echo "  Hmcon Setup $VERSION"
 echo "  ---------------"
@@ -147,8 +148,9 @@ SetupGPIO="# export GPIO
 						sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
 					fi
 					sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
-
 					sed -i /boot/cmdline.txt -e "s/console=serial0,[0-9]\+ //"
+					ASK_TO_REBOOT=1
+					
                     # allow hmcon gpio access when using HM-MOD-RPI-PCB
 					# if group gpio doesn't exist, creat it and create a corresponding udev-rule
 					if ! grep gpio /etc/group >/dev/null 2>&1; then
@@ -647,7 +649,7 @@ echo "-----------"
 echo "Configuration files are located in $ETC"
 echo "Logfiles are located in $VAR/log"
 
-if [ -f "$ETC/rfd.conf" ]; then
+if [ -f "$ETC/rfd.conf" ] && [ $ASK_TO_REBOOT -eq 0 ]; then
     echo ""
     read -p "Start rfd now (Y/n)? " choice
     case "$choice" in
@@ -658,7 +660,7 @@ if [ -f "$ETC/rfd.conf" ]; then
     esac
 fi
 
-if [ -f "$ETC/hs485d.conf" ]; then
+if [ -f "$ETC/hs485d.conf" ] && [ $ASK_TO_REBOOT -eq 0 ]; then
     echo ""
     read -p "Start hs485d now (Y/n)? " choice
     case "$choice" in
@@ -669,7 +671,7 @@ if [ -f "$ETC/hs485d.conf" ]; then
     esac
 fi
 
-if [ -f "$ETC/hm-manager.json" ]; then
+if [ -f "$ETC/hm-manager.json" ] && [ $ASK_TO_REBOOT -eq 0 ]; then
     echo ""
     read -p "Start Homematic Manager now (Y/n)? " choice
     case "$choice" in
@@ -681,5 +683,15 @@ if [ -f "$ETC/hm-manager.json" ]; then
     esac
 fi
 
+if [ $ASK_TO_REBOOT -eq 1 ]; then
+    echo ""
+    read -p "Reboot required. Reboot now (Y/n)? " choice
+    case "$choice" in
+        n|N ) ;;
+        * )
+			shutdown -r now
+        ;;
+    esac
+fi
 echo ""
 echo "Have Fun :)"


### PR DESCRIPTION
- Wenn udev-rule für gpio nicht existiert (z.B. auf wheezy oder nach upgrade von wheezy auf jessie) wird sie erzeugt #13 . (Müsste noch auf wheezy getestet werden) 
- Der user hmcon wird in die dialout-gruppe übernommen #20 
- Code zur Deaktivierung der serial-console von raspi-config übernommen #14 
- Frage nach reboot eingebaut, wenn serial-console deaktiviert wird #15 
